### PR TITLE
refactor (88) : 테스트 db 분리

### DIFF
--- a/backend/team6/src/test/java/programmers/team6/domain/admin/repository/AdminVacationRequestSearchCustomTest.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/admin/repository/AdminVacationRequestSearchCustomTest.kt
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.test.context.ActiveProfiles
 import programmers.team6.domain.admin.dto.response.AdminVacationSearchCondition
 import programmers.team6.domain.admin.dto.response.AdminVacationSearchCondition.Companion.DEFAULT_APPLICANT
 import programmers.team6.domain.admin.dto.response.AdminVacationSearchCondition.Companion.DEFAULT_DATE_RANGE
@@ -45,6 +46,7 @@ import java.util.*
 import java.util.stream.Stream
 
 @DataJpaTest
+@ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(AdminVacationRequestSearchCustom::class)
 internal class AdminVacationRequestSearchCustomTest {

--- a/backend/team6/src/test/java/programmers/team6/domain/admin/service/CodeServiceIntegrationTest.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/admin/service/CodeServiceIntegrationTest.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
 import programmers.team6.domain.admin.dto.request.CodeCreateRequest
 import programmers.team6.domain.admin.entity.Code
 import programmers.team6.domain.admin.repository.AdminVacationRequestSearchTestDataFactory
@@ -28,6 +29,7 @@ import java.util.*
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(CodeService::class)
+@ActiveProfiles("test")
 internal class CodeServiceIntegrationTest {
     @Autowired
     lateinit var codeRepository: CodeRepository

--- a/backend/team6/src/test/java/programmers/team6/domain/auth/service/MemberRepositorySliceTest.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/auth/service/MemberRepositorySliceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
 import programmers.team6.domain.admin.entity.Dept
 import programmers.team6.domain.admin.repository.CodeRepository
 import programmers.team6.domain.admin.repository.DeptRepository
@@ -17,6 +18,7 @@ import programmers.team6.domain.member.repository.MemberRepository
 import programmers.team6.support.PositionMother
 import java.time.LocalDateTime
 
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional

--- a/backend/team6/src/test/java/programmers/team6/domain/member/repository/MemberSearchRepositoryTest.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/member/repository/MemberSearchRepositoryTest.kt
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
 import programmers.team6.domain.admin.entity.Dept
 import programmers.team6.domain.admin.repository.CodeRepository
 import programmers.team6.domain.admin.repository.DeptRepository
@@ -19,6 +20,7 @@ import java.time.LocalDateTime
 @DataJpaTest
 @Import(MemberSearchRepository::class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 internal class MemberSearchRepositoryTest @Autowired constructor(
     private val memberRepository: MemberRepository,
     private val deptRepository: DeptRepository,

--- a/backend/team6/src/test/java/programmers/team6/domain/vacation/repository/ApprovalStepRepositoryTests.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/vacation/repository/ApprovalStepRepositoryTests.kt
@@ -9,8 +9,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 import programmers.team6.domain.admin.entity.Code
 import programmers.team6.domain.admin.entity.Dept
 import programmers.team6.domain.admin.repository.CodeRepository

--- a/backend/team6/src/test/java/programmers/team6/domain/vacation/repository/ApprovalStepRepositoryTests.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/vacation/repository/ApprovalStepRepositoryTests.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.test.context.ActiveProfiles
 import programmers.team6.domain.admin.entity.Code
 import programmers.team6.domain.admin.entity.Dept
 import programmers.team6.domain.admin.repository.CodeRepository
@@ -23,6 +24,7 @@ import programmers.team6.domain.vacation.enums.VacationRequestStatus
 import java.time.LocalDateTime
 
 @DataJpaTest
+@ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ApprovalStepRepositoryTests {
 

--- a/backend/team6/src/test/java/programmers/team6/domain/vacation/repository/VacationInfoRepositoryTest.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/vacation/repository/VacationInfoRepositoryTest.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import programmers.team6.domain.vacation.entity.VacationInfo
 import programmers.team6.domain.vacation.repository.factory.TestMemberFactory
@@ -16,6 +17,7 @@ import java.time.LocalDate
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional
 @Import(value = [TestMemberFactory::class])
+@ActiveProfiles("test")
 internal class VacationInfoRepositoryTest @Autowired constructor(
 
     private val vacationInfoRepository: VacationInfoRepository,

--- a/backend/team6/src/test/java/programmers/team6/domain/vacation/service/VacationServiceIntegrationTest.kt
+++ b/backend/team6/src/test/java/programmers/team6/domain/vacation/service/VacationServiceIntegrationTest.kt
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
 import programmers.team6.domain.admin.entity.Code
 import programmers.team6.domain.admin.entity.Dept
 import programmers.team6.domain.admin.repository.CodeRepository
@@ -40,6 +41,7 @@ import java.time.LocalDateTime
     DeptService::class,
     VacationRequestSearchRepository::class
 )
+@ActiveProfiles("test")
 class VacationServiceIntegrationTest {
 
     @Autowired

--- a/backend/team6/src/test/java/programmers/team6/global/config/SecurityConfigTest.kt
+++ b/backend/team6/src/test/java/programmers/team6/global/config/SecurityConfigTest.kt
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -21,6 +22,7 @@ import java.util.*
 @Transactional
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 internal class SecurityConfigTest {
     @Autowired
     lateinit var mockMvc: MockMvc


### PR DESCRIPTION

## #️⃣연관된 이슈 번호
- close #88

## 📝작업 내용
- 테스트 코드 분리 
- application-test.yml 추가 필요 (team6_test 데이터베이스 생성 필)

```java
spring:
  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver
    url: jdbc:mysql://localhost:3306/team6_test
    username:
    password: 

  jpa:
    open-in-view: true
    hibernate:
      ddl-auto: create

    properties:
      hibernate:
        naming:
          physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
        show_sql: true
        format_sql: true
        dialect: org.hibernate.dialect.MySQL8Dialect

```   
-  

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함


